### PR TITLE
Fix: Add missing emiter.h include in dataPool.c

### DIFF
--- a/src/codeGeneration/dataPool.c
+++ b/src/codeGeneration/dataPool.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "./codegen.h"
+#include "./emiter.h"
 
 StringEntry *findStringLit(CodeGenContext *ctx, const char *str, size_t len){
     StringEntry *entry = ctx->stringPool;


### PR DESCRIPTION
- Added emiter.h include to resolve implicit declaration error
- Function emitDataLabel was being called without proper declaration
- Fixes compilation error in dataPool.c