### PR TITLE
refactor: strings

### DIFF
--- a/examples/AddFn.orn
+++ b/examples/AddFn.orn
@@ -1,3 +1,5 @@
+import "../lib/stdio";
+
 // this is a simple add program
 
 fn add(a: int, b:int) -> int {
@@ -6,4 +8,4 @@ fn add(a: int, b:int) -> int {
 
 const x: int  = 10;
 const y: int = add(x, 5);
-print(y);
+print_int(y);

--- a/examples/CountToTen.orn
+++ b/examples/CountToTen.orn
@@ -1,12 +1,14 @@
+import "../lib/stdio";
+
 // Count from 0 up to ten
 
 let x: int = 0;
 const newLine: string = ",\n";
 
 while x <= 10 {
-    print(x);
+    print_int(x);
     if x < 10 {
-        print(newLine);
+        print_string(newLine);
     }
     x++;
 };

--- a/examples/Fibo.orn
+++ b/examples/Fibo.orn
@@ -1,3 +1,5 @@
+import "../lib/stdio";
+
 fn fibonacci(n: int) -> int {
     if (n <= 1) {
         return n;
@@ -7,4 +9,4 @@ fn fibonacci(n: int) -> int {
 }
 
 const result: int = fibonacci(10);
-print(result);
+print_int(result);

--- a/examples/Person.orn
+++ b/examples/Person.orn
@@ -1,3 +1,5 @@
+import "../lib/stdio";
+
 struct Person {
     age: int
     score: int
@@ -11,6 +13,6 @@ player.score = 100;
 const bonus: int = 10;
 player.score += bonus;
 
-print(player.age);    // Should print 25
-print("\n");
-print(player.score);  // Should print 110
+print_int(player.age);    // Should print 25
+print_string("\n");
+print_int(player.score);  // Should print 110

--- a/examples/Rectangle.orn
+++ b/examples/Rectangle.orn
@@ -1,3 +1,5 @@
+import "../lib/stdio";
+
 struct Rectangle {
     width: int
     height: int
@@ -14,9 +16,9 @@ const double_height: int = rect.height * 2;
 const perimeter: int = double_width + double_height;
 
 print(rect.width);    // Should print 5
-print("\n");
+print_string("\n"); 
 print(rect.height);   // Should print 3
-print("\n");
+print_string("\n"); 
 print(area);          // Should print 15
-print("\n");
+print_string("\n"); 
 print(perimeter);     // Should print 16

--- a/lib/stdio.orn
+++ b/lib/stdio.orn
@@ -1,4 +1,5 @@
 import "str/itoa";
+import "str/str";
 
 export fn print_int(n: i64) -> void {
     let buf: char[32];
@@ -12,4 +13,9 @@ export fn print_int(n: i64) -> void {
     let end: *char = ptr + 31;
     let len: i64 = end - start;
     syscall(1, 1, start, len, 0, 0, 0);
+}
+
+export fn print_str(s: *char) -> void {
+    let len: i64 = strlen(s);
+    syscall(1, 1, s, len, 0, 0, 0); // todo: bug when calling strlen directly on the call
 }

--- a/lib/str/str.orn
+++ b/lib/str/str.orn
@@ -1,0 +1,8 @@
+export fn strlen(s: str) -> i64 {
+    let i: i64 = 0;
+    while *s != 0 {
+        ++i;
+        s = s + 1; // todo: fix pointer arithmetic should allow increments
+    }
+    return i;
+}

--- a/src/backend/codeGeneration/codegen.h
+++ b/src/backend/codeGeneration/codegen.h
@@ -66,6 +66,7 @@ void genComparison(CodeGenContext *ctx, IrInstruction *inst);
 void genLogical(CodeGenContext *ctx, IrInstruction *inst);
 void genCast(CodeGenContext *ctx, IrInstruction *inst);
 void generateInstruction(CodeGenContext *ctx, IrInstruction *inst, int *paramCount);
+void genStringInit(CodeGenContext *ctx, IrInstruction *inst);
 
 char *generateAssembly(IrContext *ir, const char *moduleName, ModuleInterface **imports, int importCount);
 int writeAssemblyToFile(const char *assembly, const char *filename);

--- a/src/frontend/lexer/lexer.c
+++ b/src/frontend/lexer/lexer.c
@@ -74,10 +74,11 @@ static TokenType lookUpKeyword(const char * s, size_t len) {
 			break;
 		case 'r':
 			if (len == 6 && memcmp(s, "return", 6) == 0) return TK_RETURN;
+			if (len == 5 && memcmp(s, "rostr", 5) == 0) return TK_STRING;
 			break;
 		case 's':
+			if(len == 3 && memcmp(s, "str", 3) == 0) return TK_STR_WRAP;
 			if (len == 6 && memcmp(s, "struct", 6) == 0) return TK_STRUCT;
-			if (len == 6 && memcmp(s, "string", 6) == 0) return TK_STRING;
 			break;
 		case 't':
 			if (len == 4 && memcmp(s, "true", 4) == 0) return TK_TRUE;

--- a/src/frontend/lexer/lexer.h
+++ b/src/frontend/lexer/lexer.h
@@ -40,6 +40,7 @@ typedef enum {
 	TK_U32,
 	TK_U64,
 
+	TK_STR_WRAP,
 	TK_STRING,
 	TK_FLOAT,
 	TK_BOOL,

--- a/src/frontend/parser/parserType.c
+++ b/src/frontend/parser/parserType.c
@@ -40,6 +40,7 @@ NodeTypes getTypeNodeFromToken(TokenType type){
         case TK_U32:    return REF_U32;
         case TK_U64:    return REF_U64;
         case TK_STRING: return REF_STRING;
+        case TK_STR_WRAP: return REF_I8; /* str wrap is just syntactic sugar for *i8 */
         case TK_FLOAT:  return REF_FLOAT;
         case TK_BOOL:   return REF_BOOL;
         case TK_VOID:   return REF_VOID;
@@ -82,6 +83,7 @@ int isTypeToken(TokenType type){
             type == TK_U32 ||
             type == TK_U64 ||
             type == TK_STRING ||
+            type == TK_STR_WRAP ||
             type == TK_FLOAT ||
             type == TK_BOOL ||
             type == TK_DOUBLE ||
@@ -111,7 +113,11 @@ ASTNode parseType(TokenList* list, size_t* pos){
     Token* typeToken = &list->tokens[*pos];
     ASTNode typeNode;
 
-    if(isTypeToken(typeToken->type)){
+    if(typeToken->type == TK_STR_WRAP){
+        pointerCount++;
+        CREATE_NODE_OR_FAIL(typeNode, typeToken, REF_I8, list, pos);
+        ADVANCE_TOKEN(list, pos);
+    } else if(isTypeToken(typeToken->type)){
         NodeTypes baseType = getTypeNodeFromToken(typeToken->type);
         CREATE_NODE_OR_FAIL(typeNode, typeToken, baseType, list, pos);
         ADVANCE_TOKEN(list, pos);

--- a/src/frontend/semantic/semanticCheck.c
+++ b/src/frontend/semantic/semanticCheck.c
@@ -473,6 +473,16 @@ int validateScalarInitialization(Symbol newSymbol, ASTNode node, DataType varTyp
         return 0;
     }
 
+    if (newSymbol->isPointer && initType == TYPE_STRING) {
+        if (newSymbol->baseType != TYPE_I8) {
+            REPORT_ERROR(ERROR_TYPE_MISMATCH_STRING_TO_INT, node, context,
+                        "String literals can only be assigned to char* (i8*) pointers");
+            return 0;
+        }
+        newSymbol->isInitialized = 1;
+        return 1;  /* Skip areCompatible */
+    }
+
     CompatResult compat = areCompatible(newSymbol->type, initType);
     if (compat == COMPAT_ERROR) {
         reportErrorWithText(variableErrorCompatibleHandling(varType, initType),

--- a/src/frontend/semantic/semanticTypes.c
+++ b/src/frontend/semantic/semanticTypes.c
@@ -142,13 +142,26 @@ ASTNode getBaseTypeFromPointerChain(ASTNode typeRefNode, int *outPointerLevel) {
 
 int getStackSize(DataType type) {
     switch (type) {
-        case TYPE_I8:     case TYPE_U8:     case TYPE_BOOL:   return 1;
-        case TYPE_I16:    case TYPE_U16:                      return 2;
-        case TYPE_I32:    case TYPE_U32:    
-        case TYPE_FLOAT:                                      return 4;
-        case TYPE_I64:    case TYPE_U64:    case TYPE_DOUBLE: 
-        case TYPE_STRING: case TYPE_STRUCT: case TYPE_POINTER: return 8;
-        default: return 4;
+    case TYPE_I8:
+    case TYPE_U8:
+    case TYPE_BOOL:
+        return 1;
+    case TYPE_I16:
+    case TYPE_U16:
+        return 2;
+    case TYPE_I32:
+    case TYPE_U32:
+    case TYPE_FLOAT:
+        return 4;
+    case TYPE_I64:
+    case TYPE_U64:
+    case TYPE_DOUBLE:
+    case TYPE_STRING:
+    case TYPE_STRUCT:
+    case TYPE_POINTER:
+        return 8;
+    default:
+        return 4;
     }
 }
 
@@ -164,6 +177,7 @@ CompatResult areCompatible(DataType target, DataType source) {
     if (source == TYPE_NULL && target == TYPE_POINTER) return COMPAT_OK;
     if (target == TYPE_NULL && source == TYPE_POINTER) return COMPAT_OK;
     if (source == TYPE_NULL && target == TYPE_NULL)    return COMPAT_OK;
+    if (target == TYPE_POINTER && source == TYPE_STRING) return COMPAT_OK;
 
     /* Integer widening: same signedness, source rank <= target rank */
     if (isIntegerType(target) && isIntegerType(source)) {
@@ -429,7 +443,12 @@ DataType getExpressionType(ASTNode node, TypeCheckContext context, DataType expe
                 case REF_U32:    return TYPE_U32;
                 case REF_U64:    return TYPE_U64;
                 case REF_INT_UNRESOLVED: {
-                    return inferIntLitType(expectedType);
+                    DataType resolved = inferIntLitType(expectedType);
+                    NodeTypes resolvedNode = symbolTypeToNodeType(resolved);
+                    if (resolvedNode != null_NODE) {
+                        node->children->nodeType = resolvedNode;
+                    }
+                    return resolved;
                 }
                 case REF_FLOAT:  return TYPE_FLOAT;
                 case REF_BOOL:   return TYPE_BOOL;

--- a/src/middleend/IR/ir.c
+++ b/src/middleend/IR/ir.c
@@ -944,6 +944,18 @@ void generateStatementIr(IrContext *ctx, ASTNode node, TypeCheckContext typeCtx,
                     // todo: handle error properly instead of silently returning and generating incorrect IR
                     return;
                 }
+
+                ASTNode initValueNode = node->children->brothers->children;
+                if (sym->isPointer && sym->baseType == TYPE_I8 &&
+                    initValueNode && initValueNode->nodeType == LITERAL &&
+                    initValueNode->children && initValueNode->children->nodeType == REF_STRING) {
+
+                    IrOperand var = createVar(node->start, node->length, IR_TYPE_POINTER);
+                    IrOperand strConst = createStringConst(initValueNode->start, initValueNode->length);
+                    emitBinary(ctx, IR_STRING_INIT, var, strConst, createNone());
+                    break;
+                }
+
                 IrOperand val = generateExpressionIr(ctx, node->children->brothers->children, typeCtx, sym->type);
 
                 ASTNode typeRefChild = node->children->children;
@@ -1121,6 +1133,7 @@ static const char *opCodeToString(IrOpCode op) {
         case IR_MEMBER_LOAD: return "MEM_LOAD";
         case IR_MEMBER_STORE: return "MEM_STORE";
         case IR_ALLOC_STRUCT: return "ALLOC_STRUCT";
+        case IR_STRING_INIT: return "STRING_INIT";
         default: return "UNKNOWN";
     }
 }

--- a/src/middleend/IR/ir.h
+++ b/src/middleend/IR/ir.h
@@ -11,6 +11,8 @@ typedef enum {
     IR_NEG,
     IR_MUL,
 
+    IR_STRING_INIT,
+
     IR_BIT_AND,
     IR_BIT_OR,
     IR_BIT_XOR,

--- a/tests/frontEnd/declarations/variables.c
+++ b/tests/frontEnd/declarations/variables.c
@@ -17,7 +17,7 @@ void test_let_bool(void) {
 }
 
 void test_let_string(void) {
-    assertPass("let s: string = \"hello\";");
+    assertPass("let s: str = \"hello\";");
 }
 
 void test_const_without_init_fails(void) {
@@ -49,7 +49,7 @@ void test_let_reassignment(void) {
 }
 
 void test_type_mismatch_float_to_string_fails(void) {
-    assertFail("const s: string = 1.5f;");
+    assertFail("const s: str = 1.5f;");
 }
 
 void test_type_mismatch_string_to_float_fails(void) {
@@ -69,7 +69,7 @@ void test_type_mismatch_int_to_bool_fails(void) {
 }
 
 void test_type_mismatch_bool_to_string_fails(void) {
-    assertFail("const s: string = false;");
+    assertFail("const s: str = false;");
 }
 
 void test_type_mismatch_bool_to_float_fails(void) {

--- a/tests/frontEnd/integration/programs.c
+++ b/tests/frontEnd/integration/programs.c
@@ -32,7 +32,7 @@ void test_mixed_types_program(void) {
         "let i: int = 10;\n"
         "let f: float = 3.14f;\n"
         "let b: bool = true;\n"
-        "let s: string = \"hello\";\n"
+        "let s: str = \"hello\";\n"
         "if (b) { i = i + 1; }"
     );
 }

--- a/tests/frontEnd/types/structs.c
+++ b/tests/frontEnd/types/structs.c
@@ -5,7 +5,7 @@ void test_struct_definition(void) {
 }
 
 void test_struct_with_multiple_types(void) {
-    assertPass("struct Entity { name: string; x: float; y: float; alive: bool; }");
+    assertPass("struct Entity { name: str; x: float; y: float; alive: bool; }");
 }
 
 void test_struct_duplicate_fields_fails(void) {


### PR DESCRIPTION
This PR changes the representation of `string` in the compiler to two types:

1. **`rostr`** – An immutable string stored in the read-only data section (`.rodata`).

   * Corresponds to `const char*` → `const i8*`.
   * Comes from `.rodata`; unrelated to `orn const`.

2. **`str`** – A mutable string stored on the stack.

   * Corresponds to `char*` → `i8*`.

Each string stores its characters sequentially and includes a null terminator at the end.