### PR TITLE
Add do-while loop support: lexer, parser, semantic, codegen

### DIFF
--- a/src/frontend/lexer/lexer.c
+++ b/src/frontend/lexer/lexer.c
@@ -45,6 +45,7 @@ static TokenType lookUpKeyword(const char * s, size_t len) {
 			if(len == 4 && memcmp(s, "char", 4) == 0) return TK_I8; /* for now */
 			break;
 		case 'd': 
+			if (len == 2 && memcmp(s, "do", 2) == 0) return TK_DO;
 			if (len == 6 && memcmp(s, "double", 6) == 0) return TK_DOUBLE;
 			break;
 		case 'e':

--- a/src/frontend/lexer/lexer.h
+++ b/src/frontend/lexer/lexer.h
@@ -15,6 +15,7 @@ typedef enum {
 	TK_VOID,
 	TK_RETURN,
 	TK_WHILE,
+    TK_DO,
 	TK_FOR,
 	TK_IF,
 	TK_ELSE,

--- a/src/frontend/parser/parser.h
+++ b/src/frontend/parser/parser.h
@@ -128,6 +128,7 @@ typedef enum {
     ELSE_BRANCH,
     BLOCK_EXPRESSION,
     LOOP_STATEMENT,
+    DO_WHILE_STATEMENT,
 
     // Functions
     FUNCTION_DEFINITION,

--- a/src/frontend/parser/parserCore.c
+++ b/src/frontend/parser/parserCore.c
@@ -26,6 +26,7 @@ const StatementHandler statementHandlers[] = {
     {TK_FN,      parseFunction},
     {TK_RETURN,  parseReturnStatement},
     {TK_WHILE,   parseLoop},
+    {TK_DO,      parseDoWhileLoop},
     {TK_LBRACE,  parseBlock},
     {TK_STRUCT,  parseStruct},
     {TK_IF,      parseIf},

--- a/src/frontend/parser/parserInternal.h
+++ b/src/frontend/parser/parserInternal.h
@@ -1,3 +1,4 @@
+ASTNode parseDoWhileLoop(TokenList* list, size_t* pos);
 /**
  * @file parserInternal.h
  * @brief Internal definitions shared across parser translation units.

--- a/src/frontend/parser/parserStatement.c
+++ b/src/frontend/parser/parserStatement.c
@@ -1,3 +1,20 @@
+ASTNode parseDoWhileLoop(TokenList* list, size_t* pos){
+    if(*pos >= list->count) return NULL;
+    Token* doToken = &list->tokens[*pos];
+    ADVANCE_TOKEN(list, pos);
+
+    ASTNode loopBody, condition, loopNode;
+    EXPECT_TOKEN(list, pos, TK_LBRACE, ERROR_EXPECTED_OPENING_BRACE, "Expected '{' to start do-while body");
+    PARSE_OR_FAIL(loopBody, parseBlock(list, pos));
+    EXPECT_TOKEN(list, pos, TK_WHILE, ERROR_EXPECTED_WHILE, "Expected 'while' after do-while body");
+    ADVANCE_TOKEN(list, pos);
+    PARSE_OR_FAIL(condition, parseExpression(list, pos, PREC_NONE));
+    CREATE_NODE_OR_FAIL(loopNode, doToken, DO_WHILE_STATEMENT, list, pos);
+
+    loopNode->children = loopBody;
+    loopBody->brothers = condition;
+    return loopNode;
+}
 /**
  * @file parserStatement.c
  * @brief Statement-level parsing and control-flow constructs.

--- a/src/frontend/semantic/semanticCore.c
+++ b/src/frontend/semantic/semanticCore.c
@@ -124,6 +124,7 @@ int typeCheckNode(ASTNode node, TypeCheckContext context, DataType expectedType)
         case TERNARY_ELSE_EXPR:
         case IF_CONDITIONAL:
         case LOOP_STATEMENT:
+        case DO_WHILE_STATEMENT:
         case IF_TRUE_BRANCH:
         case ELSE_BRANCH:
             success = typeCheckChildren(node, context, expectedType);

--- a/src/middleend/IR/ir.c
+++ b/src/middleend/IR/ir.c
@@ -1050,6 +1050,39 @@ void generateStatementIr(IrContext *ctx, ASTNode node, TypeCheckContext typeCtx,
             break;
         }
 
+        case DO_WHILE_STATEMENT: {
+            ASTNode body = node->children;
+            ASTNode cond = body->brothers;
+
+            int startLab = ctx->nextLabelNum++;
+            int endLab = ctx->nextLabelNum++;
+
+            emitLabel(ctx, startLab);
+            generateStatementIr(ctx, body, typeCtx, TYPE_VOID);
+            IrOperand condOp = generateExpressionIr(ctx, cond, typeCtx, TYPE_BOOL);
+            emitIfFalse(ctx, condOp, endLab);
+            emitGoto(ctx, startLab);
+            emitLabel(ctx, endLab);
+
+            break;
+        }
+            ASTNode cond = node->children;
+            ASTNode body = cond->brothers;
+
+            int startLab = ctx->nextLabelNum++;
+            int endLab = ctx->nextLabelNum++;
+
+            emitLabel(ctx, startLab);
+
+            IrOperand condOp = generateExpressionIr(ctx, cond, typeCtx, TYPE_BOOL);
+            emitIfFalse(ctx, condOp, endLab);
+            generateStatementIr(ctx, body, typeCtx, TYPE_VOID);
+            emitGoto(ctx, startLab);
+            emitLabel(ctx, endLab);
+
+            break;
+        }
+
         case RETURN_STATEMENT: {
             if (node->children && typeCtx->currentFunction->type != TYPE_STRUCT) {
                 IrOperand retVal = generateExpressionIr(ctx, node->children, typeCtx, typeCtx->currentFunction->type);


### PR DESCRIPTION
Adds support for do-while loops to the language, including:

- Lexer: Recognizes the do keyword.
- Parser: Parses do-while loop syntax and builds the correct AST node.
- Semantic analysis: Validates do-while loop semantics.
- Code generation: Emits code for do-while loops, ensuring the loop body executes at least once and repeats while the condition is true.